### PR TITLE
sp_helpme Case Sensitivity [name] to [Name] in all_objects ORDER BY

### DIFF
--- a/sp_helpme.sql
+++ b/sp_helpme.sql
@@ -146,7 +146,7 @@ BEGIN
 					and [ep].[name] = @ExtendedPropertyName
 					AND [ep].[minor_id] = 0
 					AND [ep].[class] = 1
-			ORDER BY [Owner] ASC, [Object_type] DESC, [name] ASC;';
+			ORDER BY [Owner] ASC, [Object_type] DESC, [Name] ASC;';
 		SET @ParmDefinition = N'@ExtendedPropertyName SYSNAME';
 
 		EXEC sp_executesql @SQLString


### PR DESCRIPTION
<!-- markdownlint-disable-file -->
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

<!--- Associated issue number -->
**Issue:** Fixes #206 where [name] should be [Name] on case sensitive collations.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
I ran `sp_helpme` without parameters on a case sensitive SQL Server 2014 successfully.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the Version number of any scripts modified.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](../.github/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
